### PR TITLE
Allow to use mac address for connection to coco

### DIFF
--- a/nhc2_coco/coco_ip_by_mac.py
+++ b/nhc2_coco/coco_ip_by_mac.py
@@ -6,7 +6,7 @@ import netifaces
 from getmac import get_mac_address
 
 
-class CoCoDiscover:
+class CoCoIpByMac:
     """CoCoDiscover will help you discover NHC2.
     It will also tell you about NHC1, but the result will differ.
 
@@ -17,14 +17,11 @@ class CoCoDiscover:
     with the address, mac-address and a boolean if it's a NHC2.
     """
 
-    def __init__(self, on_discover, on_done):
-
+    def __init__(self, mac_to_match, on_found_ip):
         self._thread = threading.Thread(target=self._scan_for_nhc)
-        self._on_discover = on_discover
-        self._on_done = on_done
+        self._on_found_ip = on_found_ip
+        self._mac_to_match = mac_to_match
         self._thread.start()
-        # If we discover one, we don't want to keep looking too long...
-        self._discovered_at_least_one = False
 
     def _get_broadcast_ips(self):
         interfaces = netifaces.interfaces()
@@ -39,22 +36,28 @@ class CoCoDiscover:
         server = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
         server.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
         """ We search for all broadcast ip4s, so that we don't only search the main interface """
+        self._broadcast_ping(server)
+        searching = True
+
+        while searching:
+            ready = select.select([server], [], [], 1)
+            if ready[0]:
+                data, addr = server.recvfrom(4096)
+                raw_ip = list(map(lambda x: data[x], (6, 7, 8, 9)))
+                raw_mac = ''.join('{:02X}'.format(a) for a in data[2:6])
+                ip = "{}.{}.{}.{}".format(*raw_ip)
+                mac = raw_mac[-4:]
+                mac_to_match = self._mac_to_match.replace(':', '').upper()[-4:]
+                if mac_to_match == mac and callable(self._on_found_ip):
+                    print("found ip %s" % ip)
+                    self._on_found_ip(ip)
+                    searching = False
+            self._broadcast_ping(server)
+        server.close()
+        print('Done searching')
+
+    def _broadcast_ping(self,  server):
         broadcast_ips = self._get_broadcast_ips()
         for broadcast_ip in broadcast_ips:
             server.sendto(bytes([0x44]), (broadcast_ip, 10000))
         server.setblocking(0)
-        loops = 0
-
-        while loops < 200 and ((not self._discovered_at_least_one) or loops < 20):
-            loops = loops + 1
-            ready = select.select([server], [], [], 0.01)
-            if ready[0]:
-                data, addr = server.recvfrom(4096)
-                if data[0] == 0x44:  # NHC2 Header
-                    is_nhc2 = (len(data) >= 16) and (data[15] == 0x02)
-                    mac = get_mac_address(ip=addr[0])
-                    if self._on_discover:
-                        self._discovered_at_least_one = True
-                        self._on_discover(addr[0], mac, is_nhc2)
-        server.close()
-        self._on_done()


### PR DESCRIPTION
This will help users that don't have their CoCo on a static IP.
It's NOT recommended, but I want to provide this for users who don't have control over the DHCP server on their home network.
There will be a 6 - 12 sec disconnect when the connection with the CoCo is lost, but it's better than having to solve this manually.
Domain name in this case is preferred, as it should update when DHCP appoints a new IP, 
but hass.io has issues with DNS.
I'm waiting for hass.io to fix this. I'll give them some time... but at some point, I need to carry on.